### PR TITLE
Update Go module dependencies to Go 1.26.1

### DIFF
--- a/.github/workflows/pb-minimal-labels.yml
+++ b/.github/workflows/pb-minimal-labels.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: mheap/github-action-required-labels@v4
+            - uses: mheap/github-action-required-labels@v5
               with:
                 count: 1
                 labels: semver:major, semver:minor, semver:patch
@@ -22,7 +22,7 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: mheap/github-action-required-labels@v4
+            - uses: mheap/github-action-required-labels@v5
               with:
                 count: 1
                 labels: type:bug, type:dependency-upgrade, type:documentation, type:enhancement, type:question, type:task

--- a/.github/workflows/pb-update-pipeline.yml
+++ b/.github/workflows/pb-update-pipeline.yml
@@ -14,38 +14,30 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: actions/setup-go@v5
+            - uses: actions/setup-go@v6
               with:
                 go-version: "1.26"
             - name: Install octo
               run: |
                 #!/usr/bin/env bash
-
                 set -euo pipefail
-
                 go install -ldflags="-s -w" github.com/paketo-buildpacks/pipeline-builder/cmd/octo@latest
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - name: Update Pipeline
               id: pipeline
               run: |
                 #!/usr/bin/env bash
-
                 set -euo pipefail
-
                 if [[ -f .github/pipeline-version ]]; then
                   OLD_VERSION=$(cat .github/pipeline-version)
                 else
                   OLD_VERSION="0.0.0"
                 fi
-
                 rm .github/workflows/pb-*.yml || true
                 octo --descriptor "${DESCRIPTOR}"
-
                 PAYLOAD=$(gh api /repos/paketo-buildpacks/pipeline-builder/releases/latest)
-
                 NEW_VERSION=$(jq -n -r --argjson PAYLOAD "${PAYLOAD}" '$PAYLOAD.name')
                 echo "${NEW_VERSION}" > .github/pipeline-version
-
                 RELEASE_NOTES=$(
                   gh api \
                     -F text="$(jq -n -r --argjson PAYLOAD "${PAYLOAD}" '$PAYLOAD.body')" \
@@ -53,24 +45,24 @@ jobs:
                     -F context="paketo-buildpacks/pipeline-builder" \
                     -X POST /markdown
                 )
-
                 git add .github/
+                git add .gitignore
+                if [ -f scripts/build.sh ]; then
+                  git add scripts/build.sh
+                fi
                 git checkout -- .
-
                 echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
                 echo "new-version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
-
-                DELIMITER=$(openssl rand -hex 16) # roughly the same entropy as uuid v4 used in https://github.com/actions/toolkit/blob/b36e70495fbee083eb20f600eafa9091d832577d/packages/core/src/file-command.ts#L28
-                printf "release-notes<<%s\n%s\n%s\n" "${DELIMITER}" "${RELEASE_NOTES}" "${DELIMITER}" >> "${GITHUB_OUTPUT}" # see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+                DELIMITER=$(openssl rand -hex 16)
+                printf "release-notes<<%s\n%s\n%s\n" "${DELIMITER}" "${RELEASE_NOTES}" "${DELIMITER}" >> "${GITHUB_OUTPUT}"
               env:
                 DESCRIPTOR: .github/pipeline-descriptor.yml
-                GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-            - uses: peter-evans/create-pull-request@v7
+                GH_TOKEN: ${{ secrets.PAT }}
+            - uses: peter-evans/create-pull-request@v8
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
                 body: |-
                     Bumps pipeline from `${{ steps.pipeline.outputs.old-version }}` to `${{ steps.pipeline.outputs.new-version }}`.
-
                     <details>
                     <summary>Release Notes</summary>
                     ${{ steps.pipeline.outputs.release-notes }}
@@ -78,10 +70,9 @@ jobs:
                 branch: update/pipeline
                 commit-message: |-
                     Bump pipeline from ${{ steps.pipeline.outputs.old-version }} to ${{ steps.pipeline.outputs.new-version }}
-
                     Bumps pipeline from ${{ steps.pipeline.outputs.old-version }} to ${{ steps.pipeline.outputs.new-version }}.
                 delete-branch: true
                 labels: semver:patch, type:task
                 signoff: true
                 title: Bump pipeline from ${{ steps.pipeline.outputs.old-version }} to ${{ steps.pipeline.outputs.new-version }}
-                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+                token: ${{ secrets.PAT }}


### PR DESCRIPTION
## Summary
- Update go.mod dependencies to Go 1.26.1
- Fix Update Pipeline workflow: use `GH_TOKEN` for gh CLI, correct secrets for initializ org
- Update GitHub Actions to latest versions (setup-go v6, checkout v6, create-pull-request v8)

## Test plan
- [ ] Unit tests pass
- [ ] Create Package Test passes
- [ ] Update Pipeline workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)